### PR TITLE
Flesh out the CLI

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
     ],
     entry_points={
         'console_scripts': [
-            'cocoa=hotchocolate:cli',
+            'cocoa=hotchocolate.cli:cli',
         ],
     },
 )

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ setup(
     packages=find_packages(SOURCE),
     package_dir={'': SOURCE},
     install_requires=[
+        'click>=6.7,<7',
         'python-dateutil>=2.6.0,<3',
         'Jinja2>=2.9.5,<3',
         'Markdown>=2.6.8,<3',
@@ -45,7 +46,7 @@ setup(
     ],
     entry_points={
         'console_scripts': [
-            'cocoa=hotchocolate:main',
+            'cocoa=hotchocolate:cli',
         ],
     },
 )

--- a/src/hotchocolate/__init__.py
+++ b/src/hotchocolate/__init__.py
@@ -188,22 +188,3 @@ class Post(Article):
     @property
     def output_path(self):
         return self.date.strftime('%Y/%m/') + self.slug
-
-
-import click
-
-
-@click.group()
-def cli():
-    pass
-
-
-@cli.command('clean', help='remove the generated HTML')
-def clean():
-    print('clean')
-
-
-@cli.command('build', help='(re)build the HTML for the website')
-def build():
-    site = Site.from_folder('content')
-    site.build('output')

--- a/src/hotchocolate/__init__.py
+++ b/src/hotchocolate/__init__.py
@@ -190,7 +190,20 @@ class Post(Article):
         return self.date.strftime('%Y/%m/') + self.slug
 
 
-def main():
-    print('Welcome to Cacao!')
+import click
+
+
+@click.group()
+def cli():
+    pass
+
+
+@cli.command('clean', help='remove the generated HTML')
+def clean():
+    print('clean')
+
+
+@cli.command('build', help='(re)build the HTML for the website')
+def build():
     site = Site.from_folder('content')
     site.build('output')

--- a/src/hotchocolate/cli.py
+++ b/src/hotchocolate/cli.py
@@ -46,6 +46,7 @@ def serve():
     os.chdir('output')
     if shutil.which('docker'):
         # TODO: Don't error if the container is already running
+        # TODO: Let the user choose what port to use
         subprocess.check_call(
             ['docker', 'run', '-d', '-p', '8900:80',
              '-v', '%s:/usr/local/apache2/htdocs' % os.path.abspath(os.curdir),
@@ -54,6 +55,7 @@ def serve():
             stderr=subprocess.PIPE
         )
     else:
+        # TODO: Add support for a server with http.server
         print('Running the local web server requires Docker')
         sys.exit(1)
     print('Web server runnning on http://localhost:8900/')

--- a/src/hotchocolate/cli.py
+++ b/src/hotchocolate/cli.py
@@ -1,0 +1,76 @@
+# -*- encoding: utf-8
+
+import os
+import shutil
+import subprocess
+import sys
+
+import click
+
+from . import Site
+
+
+@click.group()
+def cli():
+    pass
+
+
+@cli.command('build', help='(re)build the HTML for the website')
+def build():
+    """
+    Take the content folder and build it.
+    """
+    site = Site.from_folder('content')
+    site.build('output')
+
+
+@cli.command('clean', help='remove the generated HTML')
+def clean():
+    """
+    Delete the output folder, if it exists.
+    """
+    try:
+        shutil.rmtree('output')
+    except FileNotFoundError:
+        pass
+
+
+@cli.command('serve', help='serve the generated website on a local port')
+def serve():
+    """
+    Start a server on port 8900.
+    """
+    site = Site.from_folder('content')
+    site.build('output')
+
+    os.chdir('output')
+    if shutil.which('docker'):
+        # TODO: Don't error if the container is already running
+        subprocess.check_call(
+            ['docker', 'run', '-d', '-p', '8900:80',
+             '-v', '%s:/usr/local/apache2/htdocs' % os.path.abspath(os.curdir),
+             'httpd'],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE
+        )
+    else:
+        print('Running the local web server requires Docker')
+        sys.exit(1)
+    print('Web server runnning on http://localhost:8900/')
+
+
+@cli.command('publish', help='build the HTML for publication')
+def publish():
+    """
+    The ``build`` command won't clean up pages or links that no longer exist.
+    This command builds a fresh copy of the site, free of dead links.
+    """
+    for f in os.listdir('output'):
+        path = os.path.join('output', f)
+        if os.path.isdir(path):
+            shutil.rmtree(path)
+        else:
+            os.unlink(path)
+
+    site = Site.from_folder('content')
+    site.build('output')


### PR DESCRIPTION
This patch adds:

* Proper CLI verbs (`build`, `clean`, `serve` and `publish`)
* Moves the CLI code into a dedicated file
* Tips my hand about more Docker integration down the line