### PR TITLE
[WIP] Improve the handling of feeds

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,8 +39,6 @@ setup(
         'beautifulsoup4>=4.6.0,<5',
         'click>=6.7,<7',
         'csscompressor>=0.9.4,<1',
-        'docker>=2.0.2,<3',
-        'feedgenerator>=1.9,<2',
         'htmlmin>=0.1.10,<0.2',
         'python-dateutil>=2.6.0,<3',
         'Jinja2>=2.9.5,<3',

--- a/src/hotchocolate/feeds.py
+++ b/src/hotchocolate/feeds.py
@@ -51,11 +51,12 @@ def get_feed_template(name):
         return env.get_template(name)
 
 
-def build_atom_feed(site, posts):
+def build_atom_feed(site, posts, max_posts=MAX_POSTS):
     """
     Given a list of posts, return a rendered Atom feed.
     """
     template = get_feed_template('atom.xml')
+    posts = sorted(posts, key=lambda p: p.metadata['date'], reverse=True)
     for post in posts:
         post.metadata['tag_uri'] = get_tag_uri(
             url=site.settings['url'] + post.metadata['slug'],
@@ -63,7 +64,7 @@ def build_atom_feed(site, posts):
         )
     atom_xml = template.render(
         site=site,
-        posts=posts[:MAX_POSTS],
+        posts=posts[:max_posts],
         updated_date=str(datetime.now())
     )
     return utils.minify_xml(atom_xml.encode('utf8'))

--- a/src/hotchocolate/feeds.py
+++ b/src/hotchocolate/feeds.py
@@ -36,7 +36,6 @@ def get_tag_uri(url, date):
     return 'tag:%s%s:%s%s' % (bits.hostname, d, bits.path, fragment)
 
 
-
 def get_feed_template(name):
     """
     Load a template for an XML feed.  If one isn't available in the standard

--- a/src/hotchocolate/feeds.py
+++ b/src/hotchocolate/feeds.py
@@ -1,0 +1,29 @@
+# -*- encoding: utf-8 -*-
+"""
+Builds the content feeds.
+
+This file presents functions for building several different feeds: Atom, RSS
+and JSON Feed.  All three feed types are build for sites using Hot Chocolate.
+
+"""
+
+import os
+
+import jinja2
+
+from . import templates
+
+
+def get_feed_template(name):
+    """
+    Load a template for an XML feed.  If one isn't available in the standard
+    templates directory, load from the install directory.
+    """
+    try:
+        env = templates.build_environment()
+        return env.get_template(name)
+    except jinja2.exceptions.TemplateNotFound:
+        env = templates.build_environment(template_dir=os.path.join(
+            os.path.dirname(os.path.abspath(__file__)), 'templates'
+        ))
+        return env.get_template(name)

--- a/src/hotchocolate/feeds.py
+++ b/src/hotchocolate/feeds.py
@@ -99,4 +99,3 @@ def write_all_feeds(output_dir, site, posts, max_posts=MAX_POSTS):
     rss_xml = build_rss_feed(site=site, posts=posts, max_posts=max_posts)
     with open(os.path.join(feed_dir, 'rss.xml'), 'w') as f:
         f.write(rss_xml)
-

--- a/src/hotchocolate/feeds.py
+++ b/src/hotchocolate/feeds.py
@@ -7,11 +7,34 @@ and JSON Feed.  All three feed types are build for sites using Hot Chocolate.
 
 """
 
+from datetime import datetime
 import os
+from urllib.parse import urlparse
 
 import jinja2
 
-from . import templates
+from . import templates, utils
+
+
+# How many posts to include in the feeds.
+MAX_POSTS = 20
+
+
+def get_tag_uri(url, date):
+    """
+    Creates a TagURI.
+    See http://web.archive.org/web/20110514113830/http://diveintomark.org/archives/2004/05/28/howto-atom-id
+    """
+    # Taken from feedgenerator.django.utils.feedgenerator
+    bits = urlparse(url)
+    d = ''
+    if date is not None:
+        d = ',%s' % date.strftime('%Y-%m-%d')
+    fragment = ''
+    if bits.fragment != '':
+        fragment = '/%s' % (bits.fragment)
+    return 'tag:%s%s:%s%s' % (bits.hostname, d, bits.path, fragment)
+
 
 
 def get_feed_template(name):
@@ -27,3 +50,21 @@ def get_feed_template(name):
             os.path.dirname(os.path.abspath(__file__)), 'templates'
         ))
         return env.get_template(name)
+
+
+def build_atom_feed(site, posts):
+    """
+    Given a list of posts, return a rendered Atom feed.
+    """
+    template = get_feed_template('atom.xml')
+    for post in posts:
+        post.metadata['tag_uri'] = get_tag_uri(
+            url=site.settings['url'] + post.metadata['slug'],
+            date=post.metadata['date']
+        )
+    atom_xml = template.render(
+        site=site,
+        posts=posts[:MAX_POSTS],
+        updated_date=str(datetime.now())
+    )
+    return utils.minify_xml(atom_xml.encode('utf8'))

--- a/src/hotchocolate/markdown.py
+++ b/src/hotchocolate/markdown.py
@@ -7,6 +7,7 @@ HTML, and then returns the HTML.  It doesn't do any I/O -- everything is just
 pure in-memory strings.
 """
 
+import htmlmin
 import markdown
 from markdown.extensions.codehilite import CodeHiliteExtension
 from markdown.extensions.footnotes import FootnoteExtension
@@ -59,5 +60,5 @@ def convert_markdown(source, extra_extensions=None):
         extensions.extend(extra_extensions)
 
     md = markdown.Markdown(extensions=extensions)
-    html = md.convert(source)
+    html = htmlmin.minify(md.convert(source))
     return (html, md.Meta)

--- a/src/hotchocolate/templates.py
+++ b/src/hotchocolate/templates.py
@@ -17,6 +17,11 @@ def locale_date(date):
     return date.strftime('%d %B %Y').lstrip('0')
 
 
+def rfc822_date(date):
+    """Render a date in an RSS feed."""
+    return date.strftime('%a, %d %b %Y %H:%M:%S %z')
+
+
 def render_title(title):
     return md.convert_markdown(
         title,
@@ -37,5 +42,6 @@ def build_environment(template_dir=None):
     # TODO: Extension mechanism for additional filters?
     env.filters['locale_date'] = locale_date
     env.filters['title'] = render_title
+    env.filters['rfc822_date'] = rfc822_date
 
     return env

--- a/src/hotchocolate/templates.py
+++ b/src/hotchocolate/templates.py
@@ -4,6 +4,7 @@ Provides template utilities.
 """
 
 import jinja2
+import pytz
 
 from . import markdown as md, plugins
 
@@ -18,8 +19,18 @@ def locale_date(date):
 
 
 def rfc822_date(date):
-    """Render a date in an RSS feed."""
+    """Render a date according to RFC-822 (for an RSS feed)."""
+    # TODO: Only localize if the timezone is naive
+    date = pytz.timezone('Europe/London').localize(date)
     return date.strftime('%a, %d %b %Y %H:%M:%S %z')
+
+
+def rfc3339_date(date):
+    """Render a date according to RFC-3339 (for an Atom feed)."""
+    # TODO: Only localize if the timezone is naive
+    date = pytz.timezone('Europe/London').localize(date)
+    s = date.strftime('%Y-%m-%dT%H:%M:%S%z')
+    return s[:-2] + ':' + s[-2:]
 
 
 def render_title(title):
@@ -43,5 +54,6 @@ def build_environment(template_dir=None):
     env.filters['locale_date'] = locale_date
     env.filters['title'] = render_title
     env.filters['rfc822_date'] = rfc822_date
+    env.filters['rfc3339_date'] = rfc3339_date
 
     return env

--- a/src/hotchocolate/templates/atom.xml
+++ b/src/hotchocolate/templates/atom.xml
@@ -1,0 +1,1 @@
+hello world

--- a/src/hotchocolate/templates/atom.xml
+++ b/src/hotchocolate/templates/atom.xml
@@ -1,1 +1,30 @@
-hello world
+<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+
+  <title>{{ site.settings.name }}</title>
+  <link href="{{ site.settings.url }}feeds/all.atom.xml" rel="alternate"/>
+  <id>{{ site.settings.url }}feeds/all.atom.xml</id>
+  <updated>{{ updated_date }}</updated>
+
+  <author>
+    <name>{{ site.settings.author }}</name>
+    <email>{{ site.settings.author_email }}</email>
+  </author>
+
+  {% for post in posts %}
+  <entry>
+    <title><![CDATA[{{ post.metadata.title|safe }}]]></title>
+    <link href="{{ site.settings.url }}{{ post.metadata.url }}" rel="alternate"/>
+    <published>{{ post.metadata.date }}</published>
+    {% if 'date_updated' in post.metadata %}
+    <updated>{{ post.metadata.date_updated }}</updated>
+    {% endif %}
+    <id>{{ post.metadata.tag_uri }}</id>
+    {% if 'summary' in post.metadata %}
+    <summary type="html"><![CDATA[{{ post.metadata.summary|safe }}]]></summary>
+    {% endif %}
+    <content type="html"><![CDATA[{{ post.content|safe }}]]></content>
+  </entry>
+  {% endfor %}
+
+</feed>

--- a/src/hotchocolate/templates/atom.xml
+++ b/src/hotchocolate/templates/atom.xml
@@ -2,9 +2,9 @@
 <feed xmlns="http://www.w3.org/2005/Atom">
 
   <title>{{ site.settings.name }}</title>
-  <link href="{{ site.settings.url }}feeds/all.atom.xml" rel="alternate"/>
+  <link href="{{ site.settings.url }}feeds/all.atom.xml" rel="self"/>
   <id>{{ site.settings.url }}feeds/all.atom.xml</id>
-  <updated>{{ updated_date }}</updated>
+  <updated>{{ updated_date|rfc3339_date }}</updated>
 
   <author>
     <name>{{ site.settings.author }}</name>
@@ -15,9 +15,11 @@
   <entry>
     <title><![CDATA[{{ post.metadata.title|safe }}]]></title>
     <link href="{{ site.settings.url }}{{ post.metadata.url }}" rel="alternate"/>
-    <published>{{ post.metadata.date }}</published>
+    <published>{{ post.metadata.date|rfc3339_date }}</published>
     {% if 'date_updated' in post.metadata %}
-    <updated>{{ post.metadata.date_updated }}</updated>
+    <updated>{{ post.metadata.date_updated|rfc3339_date }}</updated>
+    {% else %}
+    <updated>{{ post.metadata.date|rfc3339_date }}</updated>
     {% endif %}
     <id>{{ post.metadata.tag_uri }}</id>
     {% if 'summary' in post.metadata %}

--- a/src/hotchocolate/templates/base.html
+++ b/src/hotchocolate/templates/base.html
@@ -13,6 +13,9 @@
 
   {% include "base_head.html" %}
 
+  <link rel="alternate" type="application/rss+xml" href="/feeds/rss.xml">
+  <link rel="alternate" type="application/atom+xml" href="/feeds/all.atom.xml">
+
   <title>{% if metadata is defined and 'title' in metadata %}
       {{ metadata.title|striptags }} &mdash;
     {% elif title %}

--- a/src/hotchocolate/templates/rss.xml
+++ b/src/hotchocolate/templates/rss.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0" xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <channel>
+    <title>{{ site.settings.name }}</title>
+    <link>{{ site.settings.url }}feeds/rss.xml</link>
+    <description>{{ site.settings.description }}</description>
+    <lastBuildDate>{{ updated_date|rfc822_date }}</lastBuildDate>
+    <atom:link href="{{ site.settings.url }}feeds/all.atom.xml" rel="self" type="application/rss+xml" />
+
+  {% for post in posts %}
+  <item>
+    <title><![CDATA[{{ post.metadata.title|safe }}]]></title>
+    <link>{{ site.settings.url }}{{ post.metadata.url }}</link>
+    <pubDate>{{ post.metadata.date|rfc822_date }}</pubDate>
+    <guid isPermaLink="true">{{ site.settings.url }}{{ post.metadata.url }}</guid>
+    <dc:creator>{{ site.settings.author }}</dc:creator>
+    <description><![CDATA[{{ post.content|safe }}]]></description>
+  </item>
+  {% endfor %}
+
+  </channel>
+</rss>

--- a/src/hotchocolate/templates/rss.xml
+++ b/src/hotchocolate/templates/rss.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
-<rss version="2.0" xmlns:dc="http://purl.org/dc/elements/1.1/">
+<rss version="2.0" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:atom="http://www.w3.org/2005/Atom">
   <channel>
     <title>{{ site.settings.name }}</title>
     <link>{{ site.settings.url }}feeds/rss.xml</link>
+    <atom:link href="{{ site.settings.url }}feeds/rss.xml" rel="self" type="application/rss+xml" />
     <description>{{ site.settings.description }}</description>
     <lastBuildDate>{{ updated_date|rfc822_date }}</lastBuildDate>
-    <atom:link href="{{ site.settings.url }}feeds/all.atom.xml" rel="self" type="application/rss+xml" />
 
   {% for post in posts %}
   <item>

--- a/src/hotchocolate/utils.py
+++ b/src/hotchocolate/utils.py
@@ -6,6 +6,7 @@ import os
 import re
 import shutil
 
+import lxml.etree as etree
 from unidecode import unidecode
 
 
@@ -81,3 +82,18 @@ class Pagination:
                 next_ = '/%s/%d/' % (prefix, pageno + 1)
 
             yield Pageset(slug, posts, next_, prev_)
+
+
+def minify_xml(xml_string):
+    """
+    Remove insignificant whitespace from an XML string.
+    """
+    # Taken from the lxml docs: http://lxml.de/tutorial.html#parser-objects
+    parser = etree.XMLParser(remove_blank_text=True)
+    root = etree.XML(xml_string, parser)
+
+    for element in root.iter('*'):
+        if (element.text is not None) and not element.text.strip():
+            element.text = None
+
+    return etree.tostring(root).decode('ascii')

--- a/src/hotchocolate/utils.py
+++ b/src/hotchocolate/utils.py
@@ -12,7 +12,7 @@ from unidecode import unidecode
 
 def slugify(u):
     """Convert Unicode string into blog slug."""
-    # http://www.leancrew.com/all-this/2014/10/asciifying/
+    # Based on http://www.leancrew.com/all-this/2014/10/asciifying/
     u = re.sub(u'[–—/:;,.]', '-', u)   # replace separating punctuation
     a = unidecode(u).lower()           # best ASCII substitutions, lowercased
     a = re.sub(r'[^a-z0-9 -]', '', a)  # delete any other characters
@@ -21,12 +21,12 @@ def slugify(u):
     return a
 
 
-def chunks(l, n):
+def chunks(l, chunk_size):
     """Yield successive n-sized chunks from l."""
     # http://stackoverflow.com/a/312464/1558022
-    # Note: this only works if we know hte length of ``l``.
-    for i in range(0, len(l), n):
-        yield l[i:i + n]
+    # Note: this only works if we know the length of ``l``.
+    for i in range(0, len(l), chunk_size):
+        yield l[i:i + chunk_size]
 
 
 def lazy_copyfile(src, dst):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,8 @@ from markdown import Extension
 from markdown.preprocessors import Preprocessor
 import pytest
 
+from hotchocolate import Post
+
 
 class EmptyPreprocessor(Preprocessor):
     """
@@ -50,3 +52,15 @@ def settings_dict():
         'description': 'An example website',
         'language': 'en',
     }
+
+
+@pytest.fixture
+def example_post():
+    return Post(
+        path='/dev/null',
+        content='A post about greeting the entire globe',
+        metadata={
+            'date': '2016-07-21',
+            'title': 'Hello world'
+        }
+    )

--- a/tests/test_feeds.py
+++ b/tests/test_feeds.py
@@ -75,7 +75,7 @@ def test_updated_date_is_included(settings_dict, example_post):
     assert feed_xml.count('<updated>') == 2
 
 
-def test_updated_date_is_included(settings_dict, example_post):
+def test_summary_is_included(settings_dict, example_post):
     site = Site(settings=settings_dict)
     example_post.metadata['summary'] = 'A story about snails'
     feed_xml = feeds.build_atom_feed(

--- a/tests/test_feeds.py
+++ b/tests/test_feeds.py
@@ -55,24 +55,7 @@ def test_optional_tags_are_omitted_by_default(settings_dict, example_post):
         site=site,
         posts=[example_post]
     )
-
-    # There's an <updated> tag at the top of the feed, but we don't want
-    # it in the entries.
-    assert feed_xml.count('<updated>') == 1
-
     assert '</summary>' not in feed_xml
-
-
-def test_updated_date_is_included(settings_dict, example_post):
-    site = Site(settings=settings_dict)
-    example_post.metadata['date_updated'] = '2016-07-22'
-    feed_xml = feeds.build_atom_feed(
-        site=site,
-        posts=[example_post]
-    )
-
-    # Once at the top of the feed, once in the entry.
-    assert feed_xml.count('<updated>') == 2
 
 
 def test_summary_is_included(settings_dict, example_post):

--- a/tests/test_feeds.py
+++ b/tests/test_feeds.py
@@ -1,0 +1,19 @@
+# -*- encoding: utf-8
+
+from datetime import date
+
+import pytest
+
+from hotchocolate import feeds
+
+
+@pytest.mark.parametrize('url, date, expected_tag_uri', [
+    ('http://example.org', None, 'tag:example.org:'),
+    ('http://example.org', date(2017, 5, 24), 'tag:example.org,2017-05-24:'),
+    ('http://example.org/path/to/page', None, 'tag:example.org:/path/to/page'),
+    ('http://example.org/path/to/page', date(2017, 5, 24), 'tag:example.org,2017-05-24:/path/to/page'),
+    ('http://example.org/path/to/page#fragment', None, 'tag:example.org:/path/to/page/fragment'),
+    ('http://example.org/path/to/page#fragment', date(2017, 5, 24), 'tag:example.org,2017-05-24:/path/to/page/fragment'),
+])
+def test_get_tag_uri(url, date, expected_tag_uri):
+    assert feeds.get_tag_uri(url=url, date=date) == expected_tag_uri

--- a/tests/test_feeds.py
+++ b/tests/test_feeds.py
@@ -4,7 +4,7 @@ from datetime import date
 
 import pytest
 
-from hotchocolate import feeds
+from hotchocolate import Post, Site, feeds
 
 
 @pytest.mark.parametrize('url, date, expected_tag_uri', [
@@ -17,3 +17,71 @@ from hotchocolate import feeds
 ])
 def test_get_tag_uri(url, date, expected_tag_uri):
     assert feeds.get_tag_uri(url=url, date=date) == expected_tag_uri
+
+
+@pytest.mark.parametrize('max_posts', [1, 3, 10, 20])
+def test_max_posts_value_is_respected(settings_dict, example_post, max_posts):
+    feed_xml = feeds.build_atom_feed(
+        site=Site(settings=settings_dict),
+        posts=[example_post] * 50,
+        max_posts=max_posts
+    )
+    assert feed_xml.count('<entry>') == max_posts
+
+
+def test_posts_are_sorted_in_correct_order(settings_dict, example_post):
+    site = Site(settings=settings_dict)
+    posts = [example_post] * 10
+    posts.append(Post(
+        path='/dev/null',
+        content='A much newer post',
+        metadata={
+            'date': '3016-07-21',
+            'title': 'Hello future world'
+        }
+    ))
+    feed_xml = feeds.build_atom_feed(
+        site=site,
+        posts=posts,
+        max_posts=5
+    )
+
+    assert 'Hello future world' in feed_xml
+
+
+def test_optional_tags_are_omitted_by_default(settings_dict, example_post):
+    site = Site(settings=settings_dict)
+    feed_xml = feeds.build_atom_feed(
+        site=site,
+        posts=[example_post]
+    )
+
+    # There's an <updated> tag at the top of the feed, but we don't want
+    # it in the entries.
+    assert feed_xml.count('<updated>') == 1
+
+    assert '</summary>' not in feed_xml
+
+
+def test_updated_date_is_included(settings_dict, example_post):
+    site = Site(settings=settings_dict)
+    example_post.metadata['date_updated'] = '2016-07-22'
+    feed_xml = feeds.build_atom_feed(
+        site=site,
+        posts=[example_post]
+    )
+
+    # Once at the top of the feed, once in the entry.
+    assert feed_xml.count('<updated>') == 2
+
+
+def test_updated_date_is_included(settings_dict, example_post):
+    site = Site(settings=settings_dict)
+    example_post.metadata['summary'] = 'A story about snails'
+    feed_xml = feeds.build_atom_feed(
+        site=site,
+        posts=[example_post]
+    )
+
+    # Once at the top of the feed, once in the entry.
+    assert '</summary>' in feed_xml

--- a/tests/test_markdown.py
+++ b/tests/test_markdown.py
@@ -20,45 +20,45 @@ from hotchocolate import markdown
     ),
     (
         'An example with one paragraph.\n\nAnd a second paragraph.',
-        '<p>An example with one paragraph.</p>\n<p>And a second paragraph.</p>'
+        '<p>An example with one paragraph.</p> <p>And a second paragraph.</p>'
     ),
 
     # Examples with footnotes
     (
         'A paragraph about a puffin[^1]\n\n[^1]: A footnote about Frankenstein',
-        '<p>A paragraph about a puffin<sup id="fnref:2-1"><a class="footnote-ref" href="#fn:2-1" rel="footnote">1</a></sup></p>\n'
-        '<div class="footnote">\n'
-        '<hr />\n'
-        '<ol>\n'
-        '<li id="fn:2-1">\n'
-        '<p>A footnote about Frankenstein&#160;<a class="footnote-backref" href="#fnref:2-1" rev="footnote" title="Jump back to footnote 1 in the text">&#8617;&#xFE0E;</a></p>\n'
-        '</li>\n'
-        '</ol>\n'
+        '<p>A paragraph about a puffin<sup id=fnref:2-1><a class=footnote-ref href=#fn:2-1 rel=footnote>1</a></sup></p> '
+        '<div class=footnote> '
+        '<hr> '
+        '<ol> '
+        '<li id=fn:2-1> '
+        '<p>A footnote about Frankenstein&#160;<a class=footnote-backref href=#fnref:2-1 rev=footnote title="Jump back to footnote 1 in the text">&#8617;&#xFE0E;</a></p> '
+        '</li> '
+        '</ol> '
         '</div>'
     ),
     (
         'First with a flamingo[^1]\n\nSecond with a seagull[^2]\n\n'
         '[^1]: Footnote the First\n[^2]: Footnote the Second',
-        '<p>First with a flamingo<sup id="fnref:2-1"><a class="footnote-ref" href="#fn:2-1" rel="footnote">1</a></sup></p>\n'
-        '<p>Second with a seagull<sup id="fnref:2-2"><a class="footnote-ref" href="#fn:2-2" rel="footnote">2</a></sup></p>\n'
-        '<div class="footnote">\n'
-        '<hr />\n'
-        '<ol>\n'
-        '<li id="fn:2-1">\n'
-        '<p>Footnote the First&#160;<a class="footnote-backref" href="#fnref:2-1" rev="footnote" title="Jump back to footnote 1 in the text">&#8617;&#xFE0E;</a></p>\n'
-        '</li>\n'
-        '<li id="fn:2-2">\n'
-        '<p>Footnote the Second&#160;<a class="footnote-backref" href="#fnref:2-2" rev="footnote" title="Jump back to footnote 2 in the text">&#8617;&#xFE0E;</a></p>\n'
-        '</li>\n'
-        '</ol>\n'
+        '<p>First with a flamingo<sup id=fnref:2-1><a class=footnote-ref href=#fn:2-1 rel=footnote>1</a></sup></p> '
+        '<p>Second with a seagull<sup id=fnref:2-2><a class=footnote-ref href=#fn:2-2 rel=footnote>2</a></sup></p> '
+        '<div class=footnote> '
+        '<hr> '
+        '<ol> '
+        '<li id=fn:2-1> '
+        '<p>Footnote the First&#160;<a class=footnote-backref href=#fnref:2-1 rev=footnote title="Jump back to footnote 1 in the text">&#8617;&#xFE0E;</a></p> '
+        '</li> '
+        '<li id=fn:2-2> '
+        '<p>Footnote the Second&#160;<a class=footnote-backref href=#fnref:2-2 rev=footnote title="Jump back to footnote 2 in the text">&#8617;&#xFE0E;</a></p> '
+        '</li> '
+        '</ol> '
         '</div>'
     ),
 
     # And with some code blocks
     (
         'A snippet of shell\n\n```bash\necho "hello world"\n```',
-        '<p>A snippet of shell</p>\n'
-        '<div class="codehilite"><pre><span></span><span class="nb">echo</span> <span class="s2">&quot;hello world&quot;</span>\n'
+        '<p>A snippet of shell</p> '
+        '<div class=codehilite><pre><span></span><span class=nb>echo</span> <span class=s2>&quot;hello world&quot;</span>\n'
         '</pre></div>'
     ),
 ])
@@ -76,4 +76,4 @@ def test_renders_with_custom_extensions(md_extension):
         'First phrase\nSecond stanza\nLast line',
         extra_extensions=[md_extension]
     )
-    assert result[0] == '<p>test\ntest\ntest\ntest\ntest</p>'
+    assert result[0] == '<p>test test test test test</p>'

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,19 @@
+# -*- encoding: utf-8 -*-
+
+import pytest
+
+from hotchocolate import utils
+
+
+@pytest.mark.parametrize('xml_string, minified_string', [
+    (
+        '<root>  <a/>   <b>  </b>     </root>',
+        '<root><a/><b/></root>'
+    ),
+    (
+        '<root>  <a/>   <b>data</b>     </root>',
+        '<root><a/><b>data</b></root>'
+    ),
+])
+def test_xml_minify(xml_string, minified_string):
+    assert utils.minify_xml(xml_string) == minified_string

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,9 @@
 # -*- encoding: utf-8 -*-
 
+import string
+
+from hypothesis import example, given
+from hypothesis.strategies import text
 import pytest
 
 from hotchocolate import utils
@@ -17,3 +21,31 @@ from hotchocolate import utils
 ])
 def test_xml_minify(xml_string, minified_string):
     assert utils.minify_xml(xml_string) == minified_string
+
+
+def test_chunks():
+    x = list(range(10))
+    expected_chunks = [
+        [0, 1], [2, 3], [4, 5], [6, 7], [8, 9]
+    ]
+    for expected, actual in zip(expected_chunks, utils.chunks(x, 2)):
+        assert expected == actual
+
+
+class TestSlugify:
+
+    @given(text(min_size=1))
+    def test_character_whitelist(self, xs):
+        result = utils.slugify(xs)
+        allowed_chars = string.ascii_lowercase + string.digits + '-'
+        assert all(x in allowed_chars for x in result)
+
+    @given(text(min_size=1))
+    def test_slugify_is_lowercase(self, xs):
+        result = utils.slugify(xs)
+        assert result == result.lower()
+
+    @example('hello  world')
+    @given(text(min_size=1))
+    def test_no_repeated_hyphens(self, xs):
+        assert '--' not in utils.slugify(xs)

--- a/tox.ini
+++ b/tox.ini
@@ -3,8 +3,8 @@ envlist = py36, lint
 
 [testenv]
 deps =
-    beautifulsoup4
     coverage
+    hypothesis
     pytest-cov
     pytest
 commands =


### PR DESCRIPTION
This patch is a major reworking of the feed generation logic. The plan is to:

- [x] Support generating Atom, RSS and JSON Feed (currently only Atom is generated)
- [x] Drop the feedgenerator dependency
- [x] Reduce the size of the feeds (currently it includes every post ever written)
- [ ] Get a clean pass on the W3C validators